### PR TITLE
Two ammo display fixes

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -274,7 +274,7 @@ SW5E.consumableTypes = {
   "food": "SW5E.ConsumableFood",
   "medpac": "SW5E.ConsumableMedpac",
   "technology": "SW5E.ConsumableTechnology",
-  "ammunition": "SW5E.ConsumableAmmunition",
+  "ammo": "SW5E.ConsumableAmmunition",
   "trinket": "SW5E.ConsumableTrinket",
   "force": "SW5E.ConsumableForce",
   "tech": "SW5E.ConsumableTech"

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -399,7 +399,7 @@ export default class Item5e extends Item {
     // Define follow-up actions resulting from the item usage
     let createMeasuredTemplate = hasArea;       // Trigger a template creation
     let consumeRecharge = !!recharge.value;     // Consume recharge
-    let consumeResource = !!resource.target && (resource.type !== "ammo") // Consume a linked (non-ammo) resource
+    let consumeResource = !!resource.target && resource.type !== "ammo" && !['simpleB', 'martialB'].includes(id.weaponType); // Consume a linked (non-ammo) resource, ignore if use is from a blaster
     let consumePowerSlot = requirePowerSlot;    // Consume a power slot
     let consumeUsage = !!uses.per;              // Consume limited uses
     let consumeQuantity = uses.autoDestroy;     // Consume quantity of the item in lieu of uses


### PR DESCRIPTION
1. Allow ammunition items to show up in the dropdown picker
2. Don't prompt to consume resources if the consuming object is a blaster