### PR TITLE
Revert back to hp instead of hull/shld for compatibility

### DIFF
--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -319,6 +319,11 @@ export default class Actor5e extends Actor {
     // Proficiency
       data.attributes.prof = Math.floor((Math.max(data.details.tier, 1) + 7) / 4);
 
+    // Link hull to hp and shields to temp hp
+    data.attributes.hull.value = data.attributes.hp.value;
+    data.attributes.hull.max = data.attributes.hp.max;
+    data.attributes.shld.value = data.attributes.hp.temp;
+    data.attributes.shld.max = data.attributes.hp.tempmax;
   }
 
   /* -------------------------------------------- */

--- a/template.json
+++ b/template.json
@@ -50,6 +50,7 @@
             "crawl": 0,
             "fly": 0,
             "roll": 0,
+            "space": 0,
             "swim": 0,
             "turn": 0,
             "walk": 30,
@@ -419,21 +420,14 @@
         "dr": 0,
         "engpow": 1,
         "exhaustion": 0,
-        "hulldie": "",
-        "hulldice": 0,
-        "hull": {
-          "value": 0,
-          "max": 0,
-          "formula": ""
-        },
-        "shlddie": "",
-        "shlddice": 0,
-        "shld": {
-          "value": 0,
-          "max": 0,
-          "formula": ""
-        },
         "hsm": 1,
+        "hull": {
+          "die": "",
+          "dice": 0,
+          "formula":"",
+          "value": null,
+          "max": null
+        },
         "mods": {
           "open": 10,
           "max": 10
@@ -465,6 +459,13 @@
             "value": 0,
             "max": 0
           }
+        },
+        "shld": {
+          "die": "",
+          "dice": 0,
+          "formula":"",
+          "value": null,
+          "max": null
         },
         "shieldpow": 1,
         "sscap": 0,

--- a/templates/actors/newActor/starship.html
+++ b/templates/actors/newActor/starship.html
@@ -41,11 +41,11 @@
 			<section class="attribute health" style="box-sizing: border-box; width: 150px;">
                 <h1 class="attribute-name rollable">{{ localize "SW5E.HullPoints" }}</h1>
                 <div class="attribute-value multiple">
-                    <input name="data.attributes.hull.value" type="text" value="{{data.attributes.hull.value}}"
-                        data-dtype="Number" class="value-number" />
+                    <input name="data.attributes.hp.value" type="text" value="{{data.attributes.hp.value}}"
+                        data-dtype="Number" placeholder="0" class="value-number" />
                     <span class="value-separator">/</span>
-                    <input name="data.attributes.hull.max" type="text" value="{{data.attributes.hull.max}}"
-                        data-dtype="Number" class="value-number" />
+                    <input name="data.attributes.hp.max" type="text" value="{{data.attributes.hp.max}}"
+                        data-dtype="Number" placeholder="0" class="value-number" />
                 </div>
                 <footer class="attribute-footer hit-points">
                     <input name="data.attributes.hull.formula" class="hpformula" type="text"
@@ -57,24 +57,26 @@
 			<section class="attribute health" style="box-sizing: border-box; width: 150px;">
                 <h1 class="attribute-name rollable">{{ localize "SW5E.ShieldPoints" }}</h1>
                 <div class="attribute-value multiple">
-                    <input name="data.attributes.shld.value" type="text" value="{{data.attributes.shld.value}}"
-                        data-dtype="Number" placeholder="10" class="value-number" />
+                    <input name="data.attributes.hp.temp" type="text" value="{{data.attributes.hp.temp}}"
+                        data-dtype="Number" placeholder="0" class="value-number" />
                     <span class="value-separator">/</span>
-                    <input name="data.attributes.shld.max" type="text" value="{{data.attributes.shld.max}}"
-                        data-dtype="Number" placeholder="10" class="value-number" />
+                    <input name="data.attributes.hp.tempmax" type="text" value="{{data.attributes.hp.tempmax}}"
+                        data-dtype="Number" placeholder="0" class="value-number" />
                 </div>
                 <footer class="attribute-footer hit-points">
-                    <input name="data.attributes.shld.formula" class="hpformula" type="text"
+                    <input name="data.attributes.shld.Formula" class="hpformula" type="text"
                             placeholder="{{ localize 'SW5E.ShieldPointsFormula' }}" value="{{data.attributes.shld.formula}}" style="min-width: 150px;" />
                 </footer>
             </section>			
 			
+            {{!-- SPEED / MOVEMENT TYPES --}}
+
             <section style="box-sizing: border-box; width: 150px;">
 				<h1>{{ localize "SW5E.Movement" }}
                     <a class="config-button" data-action="movement" title="{{localize 'SW5E.MovementConfig'}}"><i class="fas fa-cog"></i></a>
                 </h1>
                 <div class="attribute-value">
-                    <span>{{data.attributes.movement.fly}} {{data.attributes.movement.units}}</span>
+                    <span>{{data.attributes.movement.space}} {{data.attributes.movement.units}}</span>
                 </div>
                 <footer class="attribute-footer" style="font-family: 'Russo One'; text-align: center;">
                     <span>Turning Speed: {{data.attributes.movement.turn}} {{data.attributes.movement.units}}</span>
@@ -92,7 +94,7 @@
         <button class="item" data-tab="effects">{{ localize "SW5E.Effects" }}</button>
     </nav>
 
-    {{!-- NPC Sheet Body --}}
+    {{!-- Starship Sheet Body --}}
     <section class="sheet-body">
         <section class="tab attributes core" data-group="primary" data-tab="attributes">
             <section class="panel abilities">


### PR DESCRIPTION
After much deliberation with the prof, hull and shield hit points are a bad idea.  Took another crack at getting the hp/temp to work and it seems to be working.

Left the dice separated out since hit die are controlled by character level.