### PR TITLE
Fix for attack ammo being consumed even if the roll dialog is canceled

### DIFF
--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -1039,7 +1039,7 @@ export default class Item5e extends Item {
 
         // Invoke the d20 roll helper
         const roll = await d20Roll(rollConfig);
-        if (roll === false) return null;
+        if (!roll) return null;
 
         // Commit ammunition consumption on attack rolls resource consumption if the attack roll was made
         if (ammo && !isObjectEmpty(ammoUpdate)) await ammo.update(ammoUpdate);


### PR DESCRIPTION
Looks like we were trying to not consume ammo already but just missed a small detail. `d20roll` returns null if it is canceled, not false.