### PR TITLE
Deployment features on ships

### DIFF
--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -12,6 +12,7 @@ import ProficiencySelector from "../apps/proficiency-selector.js";
 import {SW5E} from "../config.js";
 import Item5e from "../item/entity.js";
 import {fromUuidSynchronous} from "../helpers.js";
+import CrewDeployment from "../crew-deployment.js"
 
 /**
  * Extend the base Actor class to implement additional system-specific logic for SW5e.
@@ -3215,6 +3216,7 @@ export default class Actor5e extends Actor {
         });
 
         this.updateActiveDeployment();
+        CrewDeployment(ssDeploy, this);
     }
 
     /**
@@ -3712,6 +3714,7 @@ export default class Actor5e extends Actor {
             }
             this.deleteEmbeddedDocuments("Item", toDelete);
         }
+
     }
 
     /* -------------------------------------------- */

--- a/module/crew-deployment.js
+++ b/module/crew-deployment.js
@@ -1,0 +1,71 @@
+export default function CrewDeployment(doc, ship) {
+
+
+//Get the list of deployed party members.
+
+const deployedParty = [];
+if (doc.coord.uuid != null) {
+    deployedParty.push(doc.coord.uuid);
+}
+
+if (doc.uuid != null) {
+    deployedParty.push(doc.gunner.uuid);
+}
+
+if (doc.gunner.items != null) {
+    for (let g of doc.gunner.items) {
+        deployedParty.push(g.uuid);
+    }
+}
+
+if (doc.mechanic.uuid != null) {
+    deployedParty.push(doc.mechanic.uuid);
+}
+
+if (doc.operator.uuid != null) {
+    deployedParty.push(doc.operator.uuid);
+}
+
+if (doc.pilot.uuid != null) {
+    deployedParty.push(doc.pilot.uuid);
+}
+
+if (doc.technician.uuid != null) {
+    deployedParty.push(doc.technician.uuid);
+}   
+
+//Filter for only unique actors.
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
+let deployments = deployedParty.filter(onlyUnique);
+
+// Get the list of deployment features for each deployed actor.
+// Add the deployment features to the Starship actor.
+
+async function addItems() {
+    const values = Array.from(ship.data.items.values());
+    for (let p of deployments) {
+        if (typeof p !== "undefined") {        
+            let actorid = p.split('.');
+            let actor = game.actors.get(actorid[1]);
+            let itemsFromActor = actor.data.items.filter(t => t.data.type == "deploymentfeature");
+            console.log(itemsFromActor);
+            for(let i of itemsFromActor) {
+                if (values.some(n => n.data.name === i.data.name)) {
+                    continue;
+                }
+                else {
+                    let newItem = [];
+                    newItem.push(i);
+                    console.log(newItem)
+                    await ship.createEmbeddedDocuments("Item", newItem.map(m => m.toObject()));
+                }
+            }
+        }
+    }
+}
+    addItems();        
+
+}

--- a/module/crew-deployment.js
+++ b/module/crew-deployment.js
@@ -51,7 +51,6 @@ async function addItems() {
             let actorid = p.split('.');
             let actor = game.actors.get(actorid[1]);
             let itemsFromActor = actor.data.items.filter(t => t.data.type == "deploymentfeature");
-            console.log(itemsFromActor);
             for(let i of itemsFromActor) {
                 if (values.some(n => n.data.name === i.data.name)) {
                     continue;
@@ -59,7 +58,6 @@ async function addItems() {
                 else {
                     let newItem = [];
                     newItem.push(i);
-                    console.log(newItem)
                     await ship.createEmbeddedDocuments("Item", newItem.map(m => m.toObject()));
                 }
             }


### PR DESCRIPTION
**Auto-add deployment features to Starships**
When players or NPCs are deployed to ships via drag and drop, we can now automatically pull in their deployment features and add them to the ship. Recommend testing, but has been working for me!

_Note: does not remove deployments at this time._