### PR TITLE
Develop starship 1.5.6

### DIFF
--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -3481,12 +3481,9 @@ export default class Actor5e extends Actor {
     async ssDeployCrew(target, toDeploy) {
         if (!target) return;
 
-        console.log("DEPLOYING CREW!");
-        console.log(target);
-        console.log(toDeploy);
         const deployed = target.data.data.attributes.deployed;
         const otherShip = fromUuidSynchronous(deployed?.uuid);
-        /* if (otherShip) {
+        /*if (otherShip) {
             if (otherShip.uuid === this.uuid) {
                 if (toDeploy === deployed.deployment) return;
                 else if (["crew", "passenger"].includes(toDeploy)) {
@@ -3580,19 +3577,14 @@ export default class Actor5e extends Actor {
      * @param {string} target UUID of the target, if empty will set everyone as inactive
      */
     toggleActiveCrew(target) {
-        console.log("TOGGLING");
         const deployments = this.data.data.attributes.deployment;
-        console.log(deployments);
         const active = deployments.active;
-        console.log(active);
 
         if (target === active.value) target = null;
 
         active.value = target;
         for (const key of Object.keys(SW5E.deploymentTypes)) {
             const deployment = deployments[key];
-            console.log("DEPLOYMENT TYPE");
-            console.log(deployment);
             if (!target) {
                 deployment.active = false;
             } else if (deployment.items) {
@@ -3602,8 +3594,6 @@ export default class Actor5e extends Actor {
             }
         }
 
-        console.log("UPDATING DEPLOYMENT");
-        console.log(deployments);
         this.update({"data.attributes.deployment": deployments});
         return active.value;
     }

--- a/module/actor/sheets/newSheet/starship.js
+++ b/module/actor/sheets/newSheet/starship.js
@@ -149,11 +149,9 @@ export default class ActorSheet5eStarship extends ActorSheet5e {
             const deployment = this.actor.data.data.attributes.deployment[key];
             if (deployment.items) {
                 for (const uuid of deployment.items) {
-                    console.log("PETE Deploying item");
                     const actor = fromUuidSynchronous(uuid);
                     const actions = actor?.data?.items?.filter(item => ["deploymentfeature", "venture"].includes(item.type));
                     for (const action of (actions ?? [])) {
-                        console.log(action);
                         action.active = deployment.active;
                         action.derived = uuid;
                         ssActions[action.type].items.push(action);

--- a/module/actor/sheets/newSheet/starship.js
+++ b/module/actor/sheets/newSheet/starship.js
@@ -149,14 +149,17 @@ export default class ActorSheet5eStarship extends ActorSheet5e {
             const deployment = this.actor.data.data.attributes.deployment[key];
             if (deployment.items) {
                 for (const uuid of deployment.items) {
+                    console.log("PETE Deploying item");
                     const actor = fromUuidSynchronous(uuid);
                     const actions = actor?.data?.items?.filter(item => ["deploymentfeature", "venture"].includes(item.type));
                     for (const action of (actions ?? [])) {
+                        console.log(action);
                         action.active = deployment.active;
                         action.derived = uuid;
                         ssActions[action.type].items.push(action);
                     }
                 }
+
             }
         }
 

--- a/templates/actors/newActor/parts/swalt-crew.html
+++ b/templates/actors/newActor/parts/swalt-crew.html
@@ -61,8 +61,13 @@
 
 
             <!-- Deployment Features -->
-            {{#with actions.deploymentFeatures as | actions |}} {{#if (not (eq actions.items.length 0))}}
+            {{#with actions.deploymentfeature as | actions |}} {{#if (not (eq actions.items.length 0))}}
                 {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=actions.label actor=actor ship=this.actor }}
+            {{/if}} {{/with}}
+
+            <!-- Ventures -->
+            {{#with actions.venture as | actions |}} {{#if (not (eq actions.items.length 0))}}
+                {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=actions.label}}
             {{/if}} {{/with}}
 
             <!-- Deployments (pilot, crew, passenger) -->

--- a/templates/actors/newActor/parts/swalt-crew.html
+++ b/templates/actors/newActor/parts/swalt-crew.html
@@ -8,14 +8,6 @@
     </ul>
 
     <ol class="group-list">
-        <!-- Deployment Features -->
-        {{#with actions.deploymentfeature as | actions |}} {{#if (not (eq actions.items.length 0))}}
-            {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=actions.label}}
-        {{/if}} {{/with}}
-        {{#with actions.venture as | actions |}} {{#if (not (eq actions.items.length 0))}}
-            {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=actions.label}}
-        {{/if}} {{/with}}
-
         <!-- Deployments (pilot, crew, passenger) -->
         {{#each config.deploymentTypes as | name key |}}
         <!-- Only show if there is at least one character on that deployment, or all deployments are being shown -->
@@ -33,7 +25,7 @@
             <ol class="group-items item-list">
                 {{#each deployment.items as | deploy |}}
                 <li
-                    class="item group-grid-deployments{{#if (eq deploy @root.data.attributes.deployment.active.value)}} active-deployment{{/if}}"
+                    class="item group-grid-deployments {{#if (eq deploy @root.data.attributes.deployment.active.value)}}active-deployment{{/if}}"
                     data-key="{{key}}"
                     data-uuid="{{deploy}}"
                     >
@@ -53,7 +45,7 @@
                     <div class="item-detail item-controls">
                         {{#if (and @root.owner deploy)}}
                         <a class="deploy-control" data-action="toggle" title="{{localize 'SW5E.DeployToggle'}}">
-                            <i class="fas {{#if (eq deploy @root.data.attributes.deployment.active.value)}}fa-check{{else}}fa-times{{/if}}"></i>
+                            <i class="fas {{#if deploy.active}}fa-check{{else}}fa-times{{/if}}"></i>
                         </a>
                         <a class="deploy-control" data-action="delete" title="{{localize 'SW5E.DeployDelete'}}">
                             <i class="fas fa-trash"></i>
@@ -63,20 +55,31 @@
                 </li>
                 {{/each}}
             </ol>
-            <!-- Deployment actions, only show is active character is deployed here, or all actions are being shown -->
-            {{#with (lookup @root.actions key) as | actions |}} {{#if (and (or deployment.active @root.showAllActions) (not (eq actions.items.length 0)))}}
-                {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=name}}
+
             {{/if}} {{/with}}
+            {{/each}}
+
+
+            <!-- Deployment Features -->
+            {{#with actions.deploymentFeatures as | actions |}} {{#if (not (eq actions.items.length 0))}}
+                {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=actions.label actor=actor ship=this.actor }}
+            {{/if}} {{/with}}
+
+            <!-- Deployments (pilot, crew, passenger) -->
+            {{#each config.deploymentTypes as | name key |}}
+                
+                <!-- Only show if there is at least one character on that deployment, or all deployments are being shown -->
+                {{#with (lookup @root.data.attributes.deployment key) as | deployment |}}
+                {{#if (or (and deployment.items deployment.items.length) deployment.value @root.showAllDeployments)}}
+
+                    <!-- Deployment actions, only show is active character is deployed here, or all actions are being shown -->
+                    {{#with (lookup @root.actions key) as | actions |}} {{#if (and (or deployment.active @root.showAllActions) (not (eq actions.items.length 0)))}}
+                        {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=name}}
+                    {{/if}} {{/with}}
+                {{/if}} {{/with}}
+            {{/each}} 
+
         </li>
-        {{else if (or deployment.value @root.showAllDeployments)}}
-            <!-- Deployment actions, only show is active character is deployed here, or all actions are being shown -->
-            {{#with (lookup @root.actions key) as | actions |}} {{#if (and (or deployment.active @root.showAllActions) (not (eq actions.items.length 0)))}}
-                {{> "systems/sw5e/templates/actors/newActor/parts/swalt-crewactions.html" actions=actions owner=@root.owner name=name}}
-            {{/if}} {{/with}}
-        {{/if}}
-        {{/with}}
-        {{/each}}
-        <li>
-    </li>
+
     </ol>
 </div>

--- a/templates/actors/newActor/parts/swalt-crewactions.html
+++ b/templates/actors/newActor/parts/swalt-crewactions.html
@@ -22,7 +22,9 @@
 
         <ol class="item-list content" style="display: block">
             {{#each actions.items as |item iid|}}
-            {{#if (or item.active @root.showAllActions)}}
+
+            <!-- Add Deployment Features -->
+            {{#if (eq item.derived @root.actor.data.attributes.deployment.active.value)}}
             <li class="item group-grid-features" data-item-id="{{item.id}}" data-derived="{{item.derived}}">
                 <div class="item-name rollable">
                     <div class="item-image" style="background-image: url('{{item.img}}')"></div>
@@ -58,6 +60,91 @@
                 {{/if}}
             </li>
             {{/if}}
+
+            <!-- Add Crew Starship Actions -->
+            {{#if (eq item.type "starshipaction")}}
+            {{#unless (eq item.data.deployment "pilot")}}
+            <li class="item group-grid-features" data-item-id="{{item.id}}" data-derived="{{item.derived}}">
+                <div class="item-name rollable">
+                    <div class="item-image" style="background-image: url('{{item.img}}')"></div>
+                    <h4>
+                        {{item.name}}
+                    </h4>
+                </div>
+
+                <div class="item-detail item-uses">
+                    {{#if item.isOnCooldown}}
+                    <a class="item-recharge rollable">{{item.labels.recharge}}</a>
+                    {{else if item.data.recharge.value}}
+                    {{localize "SW5E.Charged"}}
+
+                    {{else if item.hasUses}}
+                    <input type="text" value="{{item.data.uses.value}}" placeholder="0" />/<span>{{item.data.uses.max}}</span>
+                    {{/if}}
+                </div>
+
+                <div class="item-detail item-action">
+                    {{#if item.data.activation.type }}
+                    {{item.labels.activation}}
+                    {{/if}}
+                </div>
+
+                {{#if ../owner}}
+                <div class="item-controls item-detail">
+                    <a class="item-control item-edit" title="{{localize 'SW5E.ItemEdit'}}"><i class="fas fa-edit"></i></a>
+                    {{#if (not ../actions.derived)}}
+                    <a class="item-control item-delete" title="{{localize 'SW5E.ItemDelete'}}"><i class="fas fa-trash"></i></a>
+                    {{/if}}
+                </div>
+                {{/if}}
+            </li>
+            {{/unless}}
+            
+            <!-- Add Pilot Starship Actions -->
+            {{#if (eq item.data.deployment "pilot")}}
+            {{#if (eq @root.actor.data.attributes.deployment.pilot.active true )}}
+                <li class="item group-grid-features" data-item-id="{{item.id}}" data-derived="{{item.derived}}">
+                    <div class="item-name rollable">
+                        <div class="item-image" style="background-image: url('{{item.img}}')"></div>
+                        <h4>
+                            {{item.name}}
+                        </h4>
+                    </div>
+
+                    <div class="item-detail item-uses">
+                        {{#if item.isOnCooldown}}
+                        <a class="item-recharge rollable">{{item.labels.recharge}}</a>
+                        {{else if item.data.recharge.value}}
+                        {{localize "SW5E.Charged"}}
+
+                        {{else if item.hasUses}}
+                        <input type="text" value="{{item.data.uses.value}}" placeholder="0" />/<span>{{item.data.uses.max}}</span>
+                        {{/if}}
+                    </div>
+
+                    <div class="item-detail item-action">
+                        {{#if item.data.activation.type }}
+                        {{item.labels.activation}}
+                        {{/if}}
+                    </div>
+
+                    {{#if ../owner}}
+                    <div class="item-controls item-detail">
+                        <a class="item-control item-edit" title="{{localize 'SW5E.ItemEdit'}}"><i class="fas fa-edit"></i></a>
+                        {{#if (not ../actions.derived)}}
+                        <a class="item-control item-delete" title="{{localize 'SW5E.ItemDelete'}}"><i class="fas fa-trash"></i></a>
+                        {{/if}}
+                    </div>
+                    {{/if}}
+                </li>
+            {{/if}}
+            {{/if}}
+
+
+            {{/if}}
+
+
+
             {{/each}}
         </ol>
     </li>


### PR DESCRIPTION
* Tidies up crew deployment so crew members are on top, followed by deployment features and ventures, then starship actions.
* Removes duplicate deployment features when a crew member is deployed as the pilot
* Only shows active crew members' actions
* Commented out code referencing "OtherShip" since that was giving me an error (said OtherShip.ssUndeployCrew was not a function for some reason)

May be worth a review on v8.9. Working well on v9 but could use a little html cleanup when we've got a sec.

**Deployed, active pilot**
![image](https://user-images.githubusercontent.com/100422816/158067197-19f2659b-5a6c-4003-bef2-070b3bd9a7c0.png)

**Deployed, active crew member**
![image](https://user-images.githubusercontent.com/100422816/158067207-a6be72c0-d765-4a7a-a70b-8a207739abb5.png)
